### PR TITLE
Fix login API call

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -15,7 +15,7 @@ export const logoutSuccess = () => ({
 export const login = user =>
   async (dispatch) => {
     try {
-      const response = await userApi.login(user);
+      const response = await userApi.login({ user });
       await sessionService.saveUser(response.user);
       dispatch(loginSuccess());
     } catch (err) {


### PR DESCRIPTION
Login is not working because the login payload is expected to be wrapped inside a `user` object.

actual: `{email: '...', password: '...'}`
expected: `{user: {email: '...', password: '...'}}`

This bug was introduced at #33 