### PR TITLE
Fix lint for folders without any JS file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"start": "node node_modules/react-native/local-cli/cli.js start",
 		"test": "jest --silent",
 		"test:cover": "npm run test -- --coverage",
-		"lint": "eslint src/**"
+		"lint": "eslint src"
 	},
 	"dependencies": {
 		"humps": "^2.0.1",


### PR DESCRIPTION
## Issue
The linter was failing if there was a folder without any JS file