### PR TITLE
Add a register screen function as described in rnn documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ReactNativeBase",
+  "name": "react-native-base",
   "version": "0.0.1",
   "private": true,
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import { Navigation } from 'react-native-navigation';
-import { Provider } from 'react-redux';
 import Immutable from 'immutable';
 import { sessionService } from 'redux-react-native-session';
 
@@ -8,7 +7,7 @@ import registerScreens from './screens';
 import { LOGIN_SCREEN, MAIN_SCREEN } from './constants/screens';
 
 const store = configureStore(Immutable.Map());
-registerScreens(Provider, store);
+registerScreens(store);
 
 class App {
   constructor() {

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -1,15 +1,14 @@
-import { Navigation } from 'react-native-navigation';
-
 import LoginScreen from 'containers/LoginScreen';
 import MainScreen from 'containers/MainScreen';
 import SignUpScreen from 'containers/SignUpScreen';
-
 import {
   LOGIN_SCREEN, MAIN_SCREEN, SIGN_UP_SCREEN,
 } from 'constants/screens';
 
-export default (Provider, store) => {
-  Navigation.registerComponentWithRedux(LOGIN_SCREEN, () => LoginScreen, Provider, store);
-  Navigation.registerComponentWithRedux(MAIN_SCREEN, () => MainScreen, Provider, store);
-  Navigation.registerComponentWithRedux(SIGN_UP_SCREEN, () => SignUpScreen, Provider, store);
+import registerScreen from './registerScreen';
+
+export default (store) => {
+  registerScreen(LOGIN_SCREEN, LoginScreen, store);
+  registerScreen(MAIN_SCREEN, MainScreen, store);
+  registerScreen(SIGN_UP_SCREEN, SignUpScreen, store);
 };

--- a/src/screens/registerScreen.js
+++ b/src/screens/registerScreen.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { Navigation } from 'react-native-navigation';
+
+const registerScreen = (
+  name,
+  Component,
+  store,
+) => {
+  const ConnectedComponent = props =>
+    <Provider store={store}>
+      <Component
+        {...props}
+      />
+    </Provider>;
+  Navigation.registerComponent(name, () => ConnectedComponent);
+};
+
+export default registerScreen;


### PR DESCRIPTION
Just updating how connected screens are registered,
since `registerComponentWithRedux` [is deprecated.](https://wix.github.io/react-native-navigation/#/docs/top-level-api-migration?id=registercomponent)
Also changed package name so that it matches the standard package name pattern.