### PR TITLE
Fix navigation options not being set when registering screens

### DIFF
--- a/src/containers/LoginScreen/index.js
+++ b/src/containers/LoginScreen/index.js
@@ -28,8 +28,12 @@ LoginScreen.propTypes = {
   componentId: string.isRequired,
 };
 
-LoginScreen.navigationOptions = {
-  title: translate('SIGN_UP.title'),
+LoginScreen.options = {
+  topBar: {
+    title: {
+      text: translate('SIGN_IN.title')
+    }
+  },
 };
 
 const mapDispatch = dispatch => ({

--- a/src/containers/MainScreen/index.js
+++ b/src/containers/MainScreen/index.js
@@ -23,8 +23,12 @@ MainScreen.propTypes = {
   logout: func.isRequired
 };
 
-MainScreen.navigationOptions = {
-  title: translate('MAIN_SCREEN.title'),
+MainScreen.options = {
+  topBar: {
+    title: {
+      text: translate('MAIN_SCREEN.title')
+    }
+  },
 };
 
 const mapState = state => ({

--- a/src/containers/SignUpScreen/index.js
+++ b/src/containers/SignUpScreen/index.js
@@ -27,8 +27,12 @@ SignUpScreen.propTypes = {
   componentId: string.isRequired,
 };
 
-SignUpScreen.navigationOptions = {
-  title: translate('SIGN_UP.title')
+SignUpScreen.options = {
+  topBar: {
+    title: {
+      text: translate('SIGN_UP.title')
+    }
+  },
 };
 
 const mapDispatch = dispatch => ({

--- a/src/screens/registerScreen.js
+++ b/src/screens/registerScreen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { Provider } from 'react-redux';
 import { Navigation } from 'react-native-navigation';
 
@@ -7,12 +7,20 @@ const registerScreen = (
   Component,
   store,
 ) => {
-  const ConnectedComponent = props =>
-    <Provider store={store}>
-      <Component
-        {...props}
-      />
-    </Provider>;
+  class ConnectedComponent extends PureComponent {
+    static options = {
+      ...Component.options,
+    }
+
+    render() {
+      return (
+        <Provider store={store}>
+          {React.createElement(Component, this.props)}
+        </Provider>
+      );
+    }
+  }
+
   Navigation.registerComponent(name, () => ConnectedComponent);
 };
 

--- a/src/screens/registerScreen.js
+++ b/src/screens/registerScreen.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import { Navigation } from 'react-native-navigation';
 
@@ -7,19 +7,12 @@ const registerScreen = (
   Component,
   store,
 ) => {
-  class ConnectedComponent extends PureComponent {
-    static options = {
-      ...Component.options,
-    }
+  const ConnectedComponent = props =>
+    <Provider store={store}>
+      <Component {...props} />
+    </Provider>;
 
-    render() {
-      return (
-        <Provider store={store}>
-          {React.createElement(Component, this.props)}
-        </Provider>
-      );
-    }
-  }
+  ConnectedComponent.options = Component.options;
 
   Navigation.registerComponent(name, () => ConnectedComponent);
 };


### PR DESCRIPTION
#### Description:
* Copy options into the wrapped component
* Change Component.navigationOptions (not supported in eact-native-navigationsv2) favor of Component.options
---

#### Notes:
Fix based on https://github.com/wix/react-native-navigation/issues/1642#issuecomment-361195519
