### PR TITLE
Add context and HOC componentId/navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint src",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest --silent",
-    "test:cover": "yarn run test -- --coverage"
+    "test:cover": "yarn run test --coverage"
   },
   "dependencies": {
     "humps": "^2.0.1",

--- a/src/components/hocs/withNavigation/index.js
+++ b/src/components/hocs/withNavigation/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Navigation } from 'react-native-navigation';
+
+import Context from 'screens/screenContext';
+
+const withNavigation = Component => (props) => {
+  const navigation = componentId => ({
+    ...Navigation,
+
+    push: (...args) =>
+      Navigation.push(componentId, ...args),
+
+    pop: () => Navigation.pop(componentId),
+
+    popToRoot: () => Navigation.popToRoot(componentId),
+
+    dismissModal: () => Navigation.dismissModal(componentId),
+  });
+
+  return (
+    <Context.Consumer>
+      {componentId =>
+        <Component
+          componentId={componentId}
+          navigation={navigation(componentId)}
+          {...props}
+        />
+      }
+    </Context.Consumer>
+  );
+};
+
+export default withNavigation;

--- a/src/containers/LoginScreen/index.js
+++ b/src/containers/LoginScreen/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Text, View, Button } from 'react-native';
 import { connect } from 'react-redux';
-import { Navigation } from 'react-native-navigation';
-import { func, string } from 'prop-types';
+import { func, object } from 'prop-types';
 
 import LoginForm from 'components/user/LoginForm';
 import { login } from 'actions/userActions';
@@ -10,7 +9,7 @@ import translate from 'utils/i18n';
 import { SIGN_UP_SCREEN } from 'constants/screens';
 import styles from './styles';
 
-const LoginScreen = ({ login, componentId }) => (
+const LoginScreen = ({ login, navigation }) => (
   <View style={styles.container}>
     <Text style={styles.welcome}>
       {translate('SIGN_IN.title')}
@@ -18,14 +17,14 @@ const LoginScreen = ({ login, componentId }) => (
     <LoginForm onSubmit={user => login(user.toJS())} />
     <Button
       title={translate('SIGN_UP.title')}
-      onPress={() => Navigation.push(componentId, { component: { name: SIGN_UP_SCREEN } })}
+      onPress={() => navigation.push({ component: { name: SIGN_UP_SCREEN } })}
     />
   </View>
 );
 
 LoginScreen.propTypes = {
+  navigation: object.isRequired,
   login: func.isRequired,
-  componentId: string.isRequired,
 };
 
 LoginScreen.options = {

--- a/src/containers/SignUpScreen/index.js
+++ b/src/containers/SignUpScreen/index.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import { Text, View, Button } from 'react-native';
 import { connect } from 'react-redux';
-import { Navigation } from 'react-native-navigation';
-import { func, string } from 'prop-types';
+import { func, object } from 'prop-types';
 
 import SignUpForm from 'components/user/SignUpForm';
 import { signUp } from 'actions/userActions';
 import translate from 'utils/i18n';
 import styles from './styles';
 
-const SignUpScreen = ({ signUp, componentId }) => (
+const SignUpScreen = ({ signUp, navigation }) => (
   <View style={styles.container}>
     <Text style={styles.welcome}>
       {translate('SIGN_UP.title')}
@@ -17,14 +16,14 @@ const SignUpScreen = ({ signUp, componentId }) => (
     <SignUpForm onSubmit={user => signUp(user.toJS())} />
     <Button
       title={translate('SIGN_IN.title')}
-      onPress={() => Navigation.pop(componentId)}
+      onPress={navigation.pop}
     />
   </View>
 );
 
 SignUpScreen.propTypes = {
+  navigation: object.isRequired,
   signUp: func.isRequired,
-  componentId: string.isRequired,
 };
 
 SignUpScreen.options = {

--- a/src/screens/registerScreen.js
+++ b/src/screens/registerScreen.js
@@ -1,18 +1,32 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Navigation } from 'react-native-navigation';
+import { string } from 'prop-types';
+
+import withNavigation from 'components/hocs/withNavigation';
+import Context from 'screens/screenContext';
 
 const registerScreen = (
   name,
   Component,
   store,
 ) => {
-  const ConnectedComponent = props =>
-    <Provider store={store}>
-      <Component {...props} />
-    </Provider>;
+  const ConnectedComponent = ({ componentId, ...props }) => {
+    const NavigationComponent = withNavigation(Component);
+    return (
+      <Context.Provider value={componentId}>
+        <Provider store={store}>
+          <NavigationComponent {...props} />
+        </Provider>
+      </Context.Provider>
+    );
+  };
 
   ConnectedComponent.options = Component.options;
+
+  ConnectedComponent.propTypes = {
+    componentId: string,
+  };
 
   Navigation.registerComponent(name, () => ConnectedComponent);
 };

--- a/src/screens/screenContext.js
+++ b/src/screens/screenContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const Context = createContext();
+
+export default Context;

--- a/tests/LoginScreen.spec.js
+++ b/tests/LoginScreen.spec.js
@@ -5,6 +5,7 @@ import { sessionService } from 'redux-react-native-session';
 import Config from 'react-native-config';
 import nock from 'nock';
 
+import withNavigation from 'components/hocs/withNavigation';
 import LoginScreen from 'containers/LoginScreen';
 import configureStore from 'store/configureStore';
 
@@ -22,9 +23,10 @@ describe('<LoginScreen />', () => {
 
   beforeEach(() => {
     const store = configureStore();
+    const NavigationLogin = withNavigation(LoginScreen);
     wrapper = mount(
       <Provider store={store}>
-        <LoginScreen />
+        <NavigationLogin />
       </Provider>
     );
 

--- a/tests/SignUpScreen.spec.js
+++ b/tests/SignUpScreen.spec.js
@@ -5,6 +5,7 @@ import { sessionService } from 'redux-react-native-session';
 import Config from 'react-native-config';
 import nock from 'nock';
 
+import withNavigation from 'components/hocs/withNavigation';
 import SignUpScreen from 'containers/SignUpScreen';
 import configureStore from 'store/configureStore';
 
@@ -23,9 +24,10 @@ describe('<SignUpScreen />', () => {
 
   beforeEach(() => {
     const store = configureStore();
+    const NavigationSignUp = withNavigation(SignUpScreen);
     wrapper = mount(
       <Provider store={store}>
-        <SignUpScreen />
+        <NavigationSignUp />
       </Provider>
     );
 


### PR DESCRIPTION
This PR wraps registered screens in a context provider with componentId as value.
Then it implements a HOC that consumes this Context and injects a navigation prop with componentId already placed as the first argument of some Navigation functions.

What do you think?
