### PR TITLE
Status reducer PoC

### DIFF
--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -1,2 +1,3 @@
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
+export const LOGIN_REQUEST = 'LOGIN_REQUEST';
 export const LOGOUT_SUCCESS = 'LOGOUT_SUCCESS';

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -8,6 +8,10 @@ export const loginSuccess = () => ({
   type: types.LOGIN_SUCCESS
 });
 
+export const loginRequest = () => ({
+  type: types.LOGIN_REQUEST
+});
+
 export const logoutSuccess = () => ({
   type: types.LOGOUT_SUCCESS
 });
@@ -15,6 +19,7 @@ export const logoutSuccess = () => ({
 export const login = user =>
   async (dispatch) => {
     try {
+      dispatch(loginRequest());
       const response = await userApi.login({ user });
       await sessionService.saveUser(response.user);
       dispatch(loginSuccess());

--- a/src/constants/status.js
+++ b/src/constants/status.js
@@ -1,0 +1,7 @@
+export const NOT_STARTED = 'NOT_STARTED';
+
+export const LOADING = 'LOADING';
+
+export const SUCCESS = 'SUCCESS';
+
+export const ERROR = 'ERROR';

--- a/src/containers/LoginScreen/index.js
+++ b/src/containers/LoginScreen/index.js
@@ -6,6 +6,7 @@ import { object } from 'prop-types';
 import LoginForm from 'components/user/LoginForm';
 import { login } from 'actions/userActions';
 import translate from 'utils/i18n';
+import useLoading from 'hooks/useLoading';
 import { SIGN_UP_SCREEN } from 'constants/screens';
 import styles from './styles';
 
@@ -15,12 +16,14 @@ const LoginScreen = ({ navigation }) => {
     user => dispatch(login(user)),
     [dispatch]
   );
+  const isLoading = useLoading('LOGIN');
+
   return (
     <View style={styles.container}>
       <Text style={styles.welcome}>
         {translate('SIGN_IN.title')}
       </Text>
-      <LoginForm onSubmit={loginRequest} />
+      <LoginForm onSubmit={loginRequest} submitting={isLoading} />
       <Button
         title={translate('SIGN_UP.title')}
         onPress={() => navigation.push({ component: { name: SIGN_UP_SCREEN } })}

--- a/src/hooks/useError.js
+++ b/src/hooks/useError.js
@@ -1,0 +1,8 @@
+import { useSelector } from 'react-redux';
+
+const useError = action => useSelector(({ actionStatus }) => {
+  const { error } = actionStatus[action] || {};
+  return error;
+});
+
+export default useError;

--- a/src/hooks/useLoading.js
+++ b/src/hooks/useLoading.js
@@ -1,0 +1,9 @@
+import { useSelector } from 'react-redux';
+import { LOADING } from 'constants/status';
+
+const useLoading = action => useSelector(({ actionStatus }) => {
+  const { status } = actionStatus[action] || {};
+  return status === LOADING;
+});
+
+export default useLoading;

--- a/src/hooks/useStatus.js
+++ b/src/hooks/useStatus.js
@@ -1,0 +1,11 @@
+import { useSelector } from 'react-redux';
+
+const useStatus = action => useSelector(({ actionStatus }) => {
+  const { status, error } = actionStatus[action] || {};
+  return {
+    status,
+    error,
+  };
+});
+
+export default useStatus;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
 import { reducer as form } from 'redux-form';
 import { sessionReducer as session } from 'redux-react-native-session';
+import actionStatus from 'reducers/statusReducer';
 
 const AppReducer = combineReducers({
   form,
-  session
+  session,
+  actionStatus
 });
 
 export default AppReducer;

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -1,0 +1,38 @@
+import { produce } from 'immer';
+import { NOT_STARTED, LOADING, SUCCESS, ERROR } from 'constants/status';
+
+const handleAction = (state, action) => {
+  const { type, error } = action;
+
+  const matchesStart = /(.*)_(REQUEST)/.exec(type);
+  const matchesError = /(.*)_(ERROR)/.exec(type);
+  const matchesReset = /(.*)_(RESET)/.exec(type);
+  const matchesSuccess = /(.*)_(SUCCESS)/.exec(type);
+
+  let status = NOT_STARTED;
+  let key = null;
+
+  if (matchesStart) {
+    const [, requestName] = matchesStart;
+    key = requestName;
+    status = LOADING;
+  } else if (matchesReset) {
+    const [, requestName] = matchesReset;
+    key = requestName;
+    status = NOT_STARTED;
+  } else if (matchesError) {
+    const [, requestName] = matchesError;
+    key = requestName;
+    status = ERROR;
+  } else if (matchesSuccess) {
+    const [, requestName] = matchesSuccess;
+    key = requestName;
+    status = SUCCESS;
+  }
+
+  if (key) state[key] = { status, error };
+
+  return state;
+};
+
+export default (state = {}, action) => produce(state, draft => handleAction(draft, action));


### PR DESCRIPTION
Added a generic reducer that track the status of every action dispatched. The main goal is to reduce boilerplate and standardise status and error handling in one place.

- The status reducer matches against `ACTION_(REQUEST|ERROR|SUCCESS|RESET)` to define the status of the action between `STARTED|NOT_STARTED|LOADING|ERROR`.
- If the action has an `error` key, it will be stored alongside the status.
- Added hooks to query the store.

This way, we only need to dispatch the correct action types, and we are good to go, the statusReducer takes care of the rest, and you can use the provided hooks `useLoading` `useError` and `useStatus` to query that state for each action.