### PR TITLE
Fix validate js presence after breaking change in lib

### DIFF
--- a/src/utils/constraints.js
+++ b/src/utils/constraints.js
@@ -24,5 +24,7 @@ export const signUp = {
   }
 };
 
+validate.validators.presence.options = { allowEmpty: false };
+
 export const validations = constraints =>
   data => validate(data, constraints) || {};


### PR DESCRIPTION
## Fix validate js presence after breaking change in lib

There was a [breaking change](https://github.com/ansman/validate.js/commit/8b07b877882361c026ba01ae473ce4b417a6a345) in `validate.js` version `0.12.0`.

They decided to allow empty strings in presence validation 🤷‍♀. To be honest the presence validation works surprisingly well despite that but I found that if I was loading a form with initial values then when clearing a field the presence error message did not appear.

The version of `validate.js` was bumped in the base on May 22nd, so if you have started a new react native project since then you need to add this fix. 

It's always good to check just in case which version you are using.
