### PR TITLE
Added fastlane base config for ios

### DIFF
--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,0 +1,32 @@
+# app_identifier("[[APP_IDENTIFIER]]") # The bundle identifier of your app
+# apple_id("[[APPLE_ID]]") # Your Apple email address
+
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile
+
+for_platform :ios do
+  for_lane :release_develop do
+    app_identifier('BUNDLE_ID_HERE')
+  end
+
+  for_lane :build_develop do
+    app_identifier('BUNDLE_ID_HERE')
+  end
+
+  for_lane :release_develop do
+    app_identifier('BUNDLE_ID_HERE')
+  end
+
+  for_lane :build_develop do
+    app_identifier('BUNDLE_ID_HERE')
+  end
+
+  for_lane :release_develop do
+    app_identifier('BUNDLE_ID_HERE')
+  end
+
+  for_lane :build_develop do
+    app_identifier('BUNDLE_ID_HERE')
+  end
+end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,178 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:ios)
+
+# CONFIG VARIABLES
+username = 'APPLE_ID' # The apple id that you are using to admin the certificates eg: toptiertest@gmail.com
+xcodeproj = 'XCODEPROJ' # The xcodeproj name eg: ReactNativeBase.xcodeproj
+workspace =  'XWORKSPACE' # The xworkspace name here eg: ReactNativeBase.xcworkspace
+certificates_git_url = 'GIT_CERTS_URL' # The git repo url (use ssh) to store the certificates eg: git@github.com:mcousillas6/fastlane-certs-test.git
+
+platform :ios do
+  lane :release_develop do
+    sync_code_signing(
+      git_url: certificates_git_url,
+      username: username,
+      type: 'appstore'
+    )
+
+    ensure_git_status_clean
+
+    increment_build_number(xcodeproj: xcodeproj)
+
+    commit_version_bump(xcodeproj: xcodeproj)
+
+    add_git_tag
+
+    push_to_git_remote(remote_branch: 'develop')
+
+    build_app(
+      scheme: 'ReactNativeBase-Develop',
+      workspace: workspace,
+      include_bitcode: true,
+      export_method: 'app-store'
+    )
+
+    changelog_from_git_commits(
+      pretty: "- (%ae) %s",# Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+      date_format: "short",# Optional, lets you provide an additional date format to dates within the pretty-formatted string
+      match_lightweight_tag: false,  # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
+      merge_commit_filtering: "exclude_merges" # Optional, lets you filter out merge commits
+    )
+
+    upload_to_testflight(username: username)
+  end
+
+  lane :release_staging do
+    sync_code_signing(
+      git_url: certificates_git_url,
+      username: username,
+      type: 'appstore'
+    )
+
+    ensure_git_status_clean
+
+    increment_build_number(xcodeproj: xcodeproj)
+
+    commit_version_bump(xcodeproj: xcodeproj)
+
+    add_git_tag
+
+    push_to_git_remote(remote_branch: 'develop')
+
+    build_app(
+      scheme: 'ReactNativeBase-Staging',
+      workspace: workspace,
+      include_bitcode: true,
+      export_method: 'app-store'
+    )
+
+    changelog_from_git_commits(
+      pretty: "- (%ae) %s",# Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+      date_format: "short",# Optional, lets you provide an additional date format to dates within the pretty-formatted string
+      match_lightweight_tag: false,  # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
+      merge_commit_filtering: "exclude_merges" # Optional, lets you filter out merge commits
+    )
+
+    upload_to_testflight(username: username)
+  end
+
+  lane :release_production do
+    sync_code_signing(
+      git_url: certificates_git_url,
+      username: username,
+      type: 'appstore'
+    )
+
+    ensure_git_status_clean
+
+    increment_build_number(xcodeproj: xcodeproj)
+
+    commit_version_bump(xcodeproj: xcodeproj)
+
+    add_git_tag
+
+    push_to_git_remote(remote_branch: 'master')
+
+    build_app(
+      scheme: 'ReactNativeBase',
+      workspace: workspace,
+      include_bitcode: true,
+      export_method: 'app-store'
+    )
+
+    changelog_from_git_commits(
+      pretty: "- (%ae) %s",# Optional, lets you provide a custom format to apply to each commit when generating the changelog text
+      date_format: "short",# Optional, lets you provide an additional date format to dates within the pretty-formatted string
+      match_lightweight_tag: false,  # Optional, lets you ignore lightweight (non-annotated) tags when searching for the last tag
+      merge_commit_filtering: "exclude_merges" # Optional, lets you filter out merge commits
+    )
+
+    upload_to_testflight(username: username)
+  end
+
+  lane :build_develop do
+    sync_code_signing(
+      git_url: certificates_git_url,
+      username: username,
+      type: 'appstore'
+    )
+
+    increment_build_number(xcodeproj: xcodeproj)
+
+    build_app(
+      scheme: 'ReactNativeBase-Develop',
+      workspace: workspace,
+      include_bitcode: true,
+      export_method: 'app-store'
+    )
+  end
+
+  lane :build_staging do
+    sync_code_signing(
+      git_url: certificates_git_url,
+      username: username,
+      type: 'appstore'
+    )
+
+    increment_build_number(xcodeproj: xcodeproj)
+
+    build_app(
+      scheme: 'ReactNativeBase-Staging',
+      workspace: workspace,
+      include_bitcode: true,
+      export_method: 'app-store'
+    )
+  end
+
+  lane :build_production do
+    sync_code_signing(
+      git_url: certificates_git_url,
+      username: username,
+      type: 'appstore'
+    )
+
+    increment_build_number(xcodeproj: xcodeproj)
+
+    build_app(
+      scheme: 'ReactNativeBase',
+      workspace: workspace,
+      include_bitcode: true,
+      export_method: 'app-store'
+    )
+  end
+
+end

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -1,0 +1,54 @@
+fastlane documentation
+================
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+Install _fastlane_ using
+```
+[sudo] gem install fastlane -NV
+```
+or alternatively using `brew cask install fastlane`
+
+# Available Actions
+## iOS
+### ios release_develop
+```
+fastlane ios release_develop
+```
+
+### ios release_staging
+```
+fastlane ios release_staging
+```
+
+### ios release_production
+```
+fastlane ios release_production
+```
+
+### ios build_develop
+```
+fastlane ios build_develop
+```
+
+### ios build_staging
+```
+fastlane ios build_staging
+```
+
+### ios build_production
+```
+fastlane ios build_production
+```
+
+
+----
+
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
Added basic fastlane setup to manage code-signing, releases and builds automatically.

### `fastlane release_(develop|staging|production)`:
- Syncs your certificates (and creates it if you don't have them set up).
- Bumps the version number.
- Generates the changelog using the commit log from develop (diffing tags)
- Tags the new build on the specified branch.
- Archives and deploys to testflight.

### `fastlane build_(develop|staging|production)`:
- Just generates the .ipa for appstore distribution.