### PR TITLE
add useSelectOptions hook

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -264,7 +264,7 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - boost-for-react-native
 
 EXTERNAL SOURCES:

--- a/src/hooks/useSelectOptions.js
+++ b/src/hooks/useSelectOptions.js
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+
+export default (items, labelAttribute = 'name', valueAttribute = 'id') =>
+  useMemo(() => items.map(item => ({ label: item[labelAttribute], value: item[valueAttribute] })), [
+    items,
+    labelAttribute,
+    valueAttribute,
+  ]);


### PR DESCRIPTION
This PR adds a new hook called `useSelectOptions`, it helps reduce the amount of code needed when having to map a list of objects to use in a select.

#### Usage:
```js
const options = useSelectOptions(items); //  when item is { id, name }
const options = useSelectOptions(items, 'title'); // if the label attribute is not name
const options = useSelectOptions(items, 'name', 'type'); // if the value attibute is not id
```

Even though we don't have any selects in the base, it can be useful and it will be nice to add it. This hook has already been used in a couple of projects already.

That's why I've created this PR as a draft so we can discuss it and see if it's the right fit for the base.