### PR TITLE
add useAppState hook

### DIFF
--- a/src/hooks/useAppState.js
+++ b/src/hooks/useAppState.js
@@ -1,0 +1,29 @@
+import { useCallback, useEffect } from 'react';
+import { AppState } from 'react-native';
+
+const useAppState = settings => {
+  const { onChange, onForeground, onBackground } = settings || {};
+
+  const isValidFunction = func => {
+    return func && typeof func === 'function';
+  };
+
+  const handleAppStateChange = useCallback(
+    nextAppState => {
+      if (nextAppState === 'active') {
+        isValidFunction(onForeground) && onForeground();
+      } else if (nextAppState.match(/inactive|background/)) {
+        isValidFunction(onBackground) && onBackground();
+      }
+      isValidFunction(onChange) && onChange(nextAppState);
+    },
+    [onBackground, onChange, onForeground],
+  );
+
+  useEffect(() => {
+    AppState.addEventListener('change', handleAppStateChange);
+    return () => AppState.removeEventListener('change', handleAppStateChange);
+  }, [handleAppStateChange]);
+};
+
+export default useAppState;


### PR DESCRIPTION
This PR implements a new hook called `useAppState`. It lets you easily trigger methods when the app changes state.

Example of how I am using it in my current proyect:
```js
useAppState({ onForeground: fetchFeed });
```
So every time the user comes back to the app the feed is up to date.

This is not a functionality currently needed in the base but that could prove very useful in our projects. I created the PR as a draft so we can start a conversation on whether it should go in the base or not.