### PR TITLE
Adds basic helper to parse error responses from the backend

### DIFF
--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -1,5 +1,6 @@
 import { createThunk, createAction } from '@rootstrap/redux-tools';
 import userService from 'services/userService';
+import parseError from 'utils/parseError';
 
 export const login = createThunk('LOGIN', async user => {
   try {
@@ -7,16 +8,16 @@ export const login = createThunk('LOGIN', async user => {
       data: { user: createdUser },
     } = await userService.login({ user });
     return createdUser;
-  } catch (err) {
-    throw err.data.error;
+  } catch ({ data }) {
+    throw parseError(data);
   }
 });
 
 export const logout = createThunk('LOGOUT', async () => {
   try {
     await userService.logout();
-  } catch (err) {
-    throw err.data.error;
+  } catch ({ data }) {
+    throw parseError(data);
   }
 });
 
@@ -26,8 +27,8 @@ export const signUp = createThunk('SIGNUP', async user => {
       data: { user: createdUser },
     } = await userService.signUp({ user });
     return createdUser;
-  } catch (err) {
-    throw err.data.error;
+  } catch ({ data }) {
+    throw parseError(data);
   }
 });
 

--- a/src/locale/en.js
+++ b/src/locale/en.js
@@ -1,6 +1,7 @@
 export default {
   COMMON: {
     loading: 'Loading',
+    somethingWentWrong: 'Something Went Wrong',
   },
 
   SIGN_IN: {

--- a/src/utils/parseError.js
+++ b/src/utils/parseError.js
@@ -14,6 +14,10 @@ const parseErrors = errors => {
       return firstMessage;
     }
 
+    if (Array.isArray(errors)) {
+      return errors[0];
+    }
+
     const errorKey = Object.keys(errors)[0];
     const error = errors[errorKey][0];
     return `${errorKey} ${error}`;
@@ -32,6 +36,7 @@ const parseErrors = errors => {
  *
  * If one of those keys is present, the first message on the array will be returned
  * in other case, the first key-value pair is returned as a string.
+ * Lastly, if `errors` is an array, the first value will be returned.
  *
  * ## Examples:
  *
@@ -42,6 +47,8 @@ const parseErrors = errors => {
  * 3- `{ errors: { base: ["User not found"]}}` returns `"User not found"`
  *
  * 4- `{ errors: { firstName: ["can't be blank"]}}` returns `"firstName can't be blank"`
+ *
+ * 5- `{ errors: ['Some error'] }` returns `"Some error"`
  */
 export default data => {
   if (!data) return strings.COMMON.somethingWentWrong;

--- a/src/utils/parseError.js
+++ b/src/utils/parseError.js
@@ -1,0 +1,54 @@
+import strings from 'locale';
+
+const parseErrors = errors => {
+  if (errors) {
+    const { fullMessages, base } = errors;
+
+    if (fullMessages) {
+      const [firstMessage] = fullMessages;
+      return firstMessage;
+    }
+
+    if (base) {
+      const [firstMessage] = base;
+      return firstMessage;
+    }
+
+    const errorKey = Object.keys(errors)[0];
+    const error = errors[errorKey][0];
+    return `${errorKey} ${error}`;
+  }
+
+  return strings.COMMON.somethingWentWrong;
+};
+
+/**
+ * Parses the body of an error response.
+ *
+ * First, it checks for `error`, and `errors` presence.
+ * If error is present, that will be returned as is.
+ *
+ * Otherwise, errors will be checked, first for `fullMessages` and `base`.
+ *
+ * If one of those keys is present, the first message on the array will be returned
+ * in other case, the first key-value pair is returned as a string.
+ *
+ * ## Examples:
+ *
+ * 1- `{ error: "Unauthorized"' }` returns `"Unauthorized"`
+ *
+ * 2- `{ errors: { fullMessages: ["User not found"]}}` returns `"User not found"`
+ *
+ * 3- `{ errors: { base: ["User not found"]}}` returns `"User not found"`
+ *
+ * 4- `{ errors: { firstName: ["can't be blank"]}}` returns `"firstName can't be blank"`
+ */
+export default data => {
+  if (!data) return strings.COMMON.somethingWentWrong;
+
+  const { error, errors } = data;
+
+  if (error) return error;
+
+  return parseErrors(errors);
+};


### PR DESCRIPTION
Created a helper to parse the error responses that come from the backend.
The implementation is tied to the way the rails base returns errors (which has a few different cases).

`utils/parseErrors.js` has the source code and inline docs with the description of how it works.