### PR TITLE
Move linters to Code Climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,6 @@ jobs:
       - run:
           name: Run tests
           command: yarn test:cover
-      - run:
-          name: Run linter
-          command: yarn run lint
 
       - save_cache:
           key: dependency-cache

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -54,6 +54,8 @@ plugins:
     enabled: true
     config:
       config: ~/.eslintrc
+  nodesecurity:
+    enabled: true
 exclude_patterns:
   - "android/"
   - "ios/"


### PR DESCRIPTION
We discussed this on the Code Quality group that it would be better to centralize code quality checks like linters and other tools in Code Climate like we are doing with the other technologies (Rails, iOS and Android)