### PR TITLE
Payload required on reducers, fix tests.

### DIFF
--- a/src/reducers/sessionReducer.js
+++ b/src/reducers/sessionReducer.js
@@ -6,16 +6,16 @@ const initialState = {
   info: null,
 };
 
-const handleLoginSuccess = (state, { user }) => {
-  state.user = user;
+const handleLoginSuccess = (state, { payload }) => {
+  state.user = payload;
 };
 
 const handleLogoutSuccess = () => {
   return initialState;
 };
 
-const handleUpdateSession = (state, { session }) => {
-  state.info = session;
+const handleUpdateSession = (state, { payload }) => {
+  state.info = payload;
 };
 
 export default createReducer(initialState, {

--- a/tests/screens/LoginScreen.spec.js
+++ b/tests/screens/LoginScreen.spec.js
@@ -16,7 +16,7 @@ describe('<LoginScreen />', () => {
   let passwordInput;
 
   beforeEach(() => {
-    const store = configureStore();
+    const { store } = configureStore();
     wrapper = mount(
       <Provider store={store}>
         <LoginScreen

--- a/tests/screens/SignUpScreen.spec.js
+++ b/tests/screens/SignUpScreen.spec.js
@@ -16,7 +16,7 @@ describe('<SignUpScreen />', () => {
   let passwordConfirmationInput;
 
   beforeEach(() => {
-    const store = configureStore();
+    const { store } = configureStore();
     wrapper = mount(
       <Provider store={store}>
         <SignUpScreen


### PR DESCRIPTION
- Small fix on reducers.`createAction` sends an object with an inner `payload` property. This is already fixed on `react-redux-base`

- Small fix on tests