### PR TITLE
Fix for error in ErrorView from parsing errors after calling signUp API

### DIFF
--- a/src/components/common/ErrorView/index.js
+++ b/src/components/common/ErrorView/index.js
@@ -7,7 +7,7 @@ const ErrorView = ({ errors = {} }) => {
   const errorMessages = Object.values(errors)
     .filter(error => !!error)
     .reduce((acc, error) => {
-      error.forEach(e => acc.push(e));
+      acc.push(error);
       return acc;
     }, []);
   if (!errorMessages.length) return null;


### PR DESCRIPTION
This PR is to solve this error while signing up: 
![errorView](https://user-images.githubusercontent.com/8755889/73572034-9a97d100-444e-11ea-8fb8-9e94ecb56096.png)

After calling the sign up API and when an error has ocurred, while parsing the error it returns just the first one (in case of multiple errors) but the ErrorView is expecting an array and it gives the error shown above.

To solve it now the ErrorView just treats it as a string and not an array.

![image](https://user-images.githubusercontent.com/8755889/73572374-67a20d00-444f-11ea-9c09-6523709f16c7.png)

