### PR TITLE
Update circleCi config to use orbs + react-navigation fix lib version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,23 @@
-version: 2
+version: 2.1
+orbs:
+  node: circleci/node@1.1.6
 jobs:
-  build:
+  build-lint-and-test:
     environment:
       CC_TEST_REPORTER_ID: 61a3188d5e43ddaabd2bc378538388dfbe4b91df4015bf5af41696852eb2c3cf
-    docker:
-      - image: circleci/node:10.14.2-browsers
-
+    executor:
+      name: node/default
     steps:
       - checkout
-      - run: echo 'export PATH=${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin:$PATH' >> $BASH_ENV
+      - node/with-cache:
+          steps:
+            - run: yarn
       - run:
-          name: Install dependencies
-          command: yarn
+          name: Run linter
+          command: yarn lint
       - run:
           name: Run tests
           command: yarn test:cover
-
-      - save_cache:
-          key: dependency-cache
-          paths:
-            - ~/.cache/yarn
-
       - run:
           name: Setup Code Climate test reporter
           command: |
@@ -28,3 +25,7 @@ jobs:
             chmod +x ./cc-test-reporter
             ./cc-test-reporter before-build
             ./cc-test-reporter after-build
+workflows:
+  build-and-test:
+    jobs:
+      - build-lint-and-test

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "@react-native-community/async-storage": "1.7.1",
     "@react-native-community/masked-view": "^0.1.6",
-    "@react-navigation/native": "^5.0.0",
-    "@react-navigation/stack": "^5.0.0",
+    "@react-navigation/native": "5.0.0",
+    "@react-navigation/stack": "5.0.0",
     "@rootstrap/redux-tools": "^0.4.2",
     "axios": "^0.19.2",
     "eslint-plugin-prettier": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,7 +1284,7 @@
     shortid "^2.2.15"
     use-subscription "^1.3.0"
 
-"@react-navigation/native@^5.0.0":
+"@react-navigation/native@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.0.0.tgz#6fcf4a24249229005ddfaf40be1d35fcbe0e16c2"
   integrity sha512-+lXBHKFEsA99D7b0B4AngM1b8hjNYdKSGUyz4JtoVY9FYLEJgCUp6EhNyouMWq5yr2x+z9mPIuIMbitHKF04SA==
@@ -1299,7 +1299,7 @@
     "@react-navigation/core" "^5.0.0"
     shortid "^2.2.15"
 
-"@react-navigation/stack@^5.0.0":
+"@react-navigation/stack@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.0.0.tgz#2f6c3d0de2ff3e5f5773142e8ed237c6c77c8fad"
   integrity sha512-pOJARONdS0g4q32cB8LOAdTUv+mUNDXgbff9gx/etycFRzon7qtQuyAE7U2+CIBB/NJkqFXG64B2nBYdfEq7rQ==


### PR DESCRIPTION
This PR updates the circleCi configuration to use [orbs](https://circleci.com/orbs/)

It also locks the `react-navigation` versions to use `5.0.0` instead of being `^5.0.0`. This makes it much more stable and will save us headaches. For example, 7 hs ago a new version was released that broke the tests, could have saved a lot of time had the version numbers been fixed.