### PR TITLE
feat: add version bump script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 You can also create `.env.prod` and `.env.staging` to define environment variables for production and staging.
 
 3. Rename your new project using [react-native-rename](https://github.com/junedomingo/react-native-rename). You will also need to rename other files manually.
-Look for `develop` and `staging`'s schemes and `{BuildTarged}-Info.plist`s. You will also need to look for the following patterns inside your project files: `ReactNativeBase`, `react-native-base`, `reactnativebase`, `RNBase`.
-Replace them to your corresponding project name (following each corresponding naming convention).
-**Important**
-When looking for the patterns remember to have the `matching case` option enabled and remember to also check for these patterns in your file names.
+   Look for `develop` and `staging`'s schemes and `{BuildTarged}-Info.plist`s. You will also need to look for the following patterns inside your project files: `ReactNativeBase`, `react-native-base`, `reactnativebase`, `RNBase`.
+   Replace them to your corresponding project name (following each corresponding naming convention).
+   **Important**
+   When looking for the patterns remember to have the `matching case` option enabled and remember to also check for these patterns in your file names.
 
 4. Start on android or ios: `yarn android:{env}` or `yarn ios:{env}` (envs: `dev`, `staging`, and `prod`)
 
@@ -67,14 +67,14 @@ The repo includes configuration for using GitHub Actions to run unit tests and c
 2. On the `Test Coverage` tab, copy the `Test Reporter ID`
 3. Set the copied value as environment variable `CC_TEST_REPORTER_ID` (and repo Secrets)
 
-
 ## Sonarqube Integration
 
 1. Log into Sonarqube console (`SONAR_URL`) and create new Project key(`SONAR_PROJECT`)
 2. Generate a token for the new project and copy
 3. Set the token value as environment variable `SONAR_TOKEN`
 
-### Usage 
+### Usage
+
 ```
 sonar-scanner \
   -Dsonar.qualitygate.wait=true \
@@ -90,12 +90,35 @@ sonar-scanner \
   -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
 ```
 
+## Bump the app version
+
+We have a nifty script that bumps the app version for you!
+
+If it's your first time using it please check that the `rnbv.config.js` is correctly configured, if in doubt you can refer to the [original file](https://github.com/rootstrap/react-native-base/blob/master/rnbv.config.js) at the `react-native-base` repo.
+The iosPaths should match the envs of your repo. This should have already been changed in the rename project steps.
+
+To run the script use the following command:
+
+```
+yarn bump
+```
+
+You should see something as follows:
+
+![bump options](https://user-images.githubusercontent.com/9297073/108426679-cc770380-721a-11eb-9a3c-f42a6248648c.png)
+
+Follow the instructions in the prompt to select the version bump that you want and press enter to run it.
+
+As a result you should see something like this (example is minor bump):
+![bump results](https://user-images.githubusercontent.com/9297073/108426803-fb8d7500-721a-11eb-985d-edf56e07da5b.png)
+
 ## Build Android Release
 
 ### Configuration
 
-1. Ask a developer for the release key and place it in `/android/app`
-2. Add the following variables in `.env.prod`:
+1. Make sure that the version was already bumped if it applies. You might want to check the [bump the app version](#bump-the-app-version) section
+2. Ask a developer for the release key and place it in `/android/app`
+3. Add the following variables in `.env.prod`:
 
 ```
  RELEASE_STORE_FILE
@@ -111,10 +134,11 @@ sonar-scanner \
 
 ## Build iOS Release
 
-1. Select on Xcode the scheme of the build target you want to create the release for.
-2. For the device select **generic iOS device**.
-3. Then go to **Product** -> **Archive**.
-4. After it is done processing and the archive succeeds the **organizer** will open. Here is where you can see all the previously generated archives.
+1. Make sure that the version was already bumped if it applies. You might want to check the [bump the app version](#bump-the-app-version) section
+2. Select on Xcode the scheme of the build target you want to create the release for.
+3. For the device select **generic iOS device**.
+4. Then go to **Product** -> **Archive**.
+5. After it is done processing and the archive succeeds the **organizer** will open. Here is where you can see all the previously generated archives.
 
 ## Managing multiple environments
 
@@ -203,10 +227,9 @@ If you are looking for something quick and easy in the short term, there is one 
   ENVFILE=.env.{env} react-native run-ios
 ```
 
-
 ## Automation with Fastlane
 
-This project provides configuration for automatic build and release using [Fastlane]((https://fastlane.tools)).
+This project provides configuration for automatic build and release using [Fastlane](<(https://fastlane.tools)>).
 For more details please check configuration and Readme files for [iOS](./ios/fastlane/README.md) and [Android](android/fastlane/README.md)
 
 ## Troubleshooting
@@ -240,4 +263,3 @@ The default configuration is the following:
 - There's a defined `whitelist` where all reducers that want to be persisted must be declared.
 - The `storage` engine is `AsyncStorage` but you can change it if needed, for example: https://github.com/CodingZeal/redux-persist-sensitive-storage if you need keychan storage on iOS.
 - If you ever need to set up migrations to keep your reducers up to date, please check [this link](https://github.com/rt2zz/redux-persist#migrations).
-

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -142,7 +142,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         resValue "string", "build_config_package", "com.reactnativebase"
     }
     splits {

--- a/ios/ReactNativeBase-Develop-Info.plist
+++ b/ios/ReactNativeBase-Develop-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/ReactNativeBase-Staging-Info.plist
+++ b/ios/ReactNativeBase-Staging-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ios/ReactNativeBase/Info.plist
+++ b/ios/ReactNativeBase/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "android:bundle:dev": "cd android && ./gradlew bundleDevRelease",
     "android:bundle:staging": "cd android && ./gradlew bundleStagingRelease",
     "android:bundle:prod": "cd android && ./gradlew bundleProdRelease",
+    "bump": "./rnbv.js",
     "test": "jest",
     "test:cover": "yarn run test --coverage",
     "prettier": "prettier --write './src/**/*.js'"

--- a/rnbv.config.js
+++ b/rnbv.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  // Android build gradle path, you probably shouldn't be changing this
+  androidPath: './android/app/build.gradle',
+  iosPaths: {
+    // List all envs with the paths to their respective Info.plist files
+    dev: './ios/ReactNativeBase-Develop-Info.plist',
+    staging: './ios/ReactNativeBase-Staging-Info.plist',
+    prod: './ios/ReactNativeBase/Info.plist',
+  },
+};

--- a/rnbv.js
+++ b/rnbv.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/* eslint-disable */
+const fs = require('fs');
+const chalk = require('chalk');
+const prompts = require('prompts');
+const semver = require('semver');
+const _ = require('lodash');
+
+const envs = ['dev', 'staging', 'prod'];
+
+let config;
+
+const ANDROID_REGEX = /versionName "([.|\d]+)"/;
+const ANDROID_REGEX_CODE = /versionCode \d+/;
+const IOS_REGEX = /\s\<key\>CFBundleShortVersionString\<\/key\>\n\s+\<string\>(.+)\<\/string\>/m;
+
+function checkSemver(maybeSemver) {
+  if (!semver.valid(maybeSemver)) {
+    throw new Error(`Current version string is not semver: ${maybeSemver}`);
+  }
+}
+
+function getAndroidVersion() {
+  const file = fs.readFileSync(config.androidPath, 'utf8');
+  const [, current] = file.match(ANDROID_REGEX);
+
+  checkSemver(current);
+
+  return current;
+}
+
+function getAndroidVersionCode() {
+  const file = fs.readFileSync(config.androidPath, 'utf8');
+  const [currentLine] = file.match(ANDROID_REGEX_CODE);
+  const [current] = currentLine.match(/\d+/);
+
+  return parseInt(current, 0);
+}
+
+function getIOSVersion(env = 'dev') {
+  const file = fs.readFileSync(config.iosPaths[env], 'utf8');
+  const [_, current] = file.match(IOS_REGEX);
+
+  checkSemver(current);
+
+  return current;
+}
+
+function android(releaseType) {
+  const current = getAndroidVersion();
+  const currentCode = getAndroidVersionCode();
+  const file = fs.readFileSync(config.androidPath, 'utf8');
+  const next = semver.inc(current, releaseType);
+  const nextCode = currentCode + 1;
+  let updated = file.replace(ANDROID_REGEX, `versionName "${next}"`);
+  updated = updated.replace(ANDROID_REGEX_CODE, `versionCode ${nextCode}`);
+
+  fs.writeFileSync(config.androidPath, updated, 'utf8');
+
+  console.log(chalk.green(`Android SUCCESS! ${current} -> ${next} with version code ${nextCode}`));
+}
+
+function ios(releaseType, env = 'dev') {
+  if (!config.iosPaths[env]) return;
+
+  const current = getIOSVersion(env);
+  const file = fs.readFileSync(config.iosPaths[env], 'utf8');
+  const next = semver.inc(current, releaseType);
+  const updated = file.replace(`<string>${current}</string>`, `<string>${next}</string>`);
+
+  fs.writeFileSync(config.iosPaths[env], updated, 'utf8');
+
+  console.log(chalk.green(`iOS SUCCESS! ${env}: ${current} -> ${next}`));
+}
+
+function validate() {
+  // Validate that it has configs
+  if (_.isEmpty(config)) {
+    console.log(chalk.red(`Error: no configs found at rnbv.config.js`));
+    return false;
+  }
+  // Validate that AndroidPath exists
+  if (!fs.existsSync(config.androidPath)) {
+    console.log(chalk.red(`Error: androidPath at ${config.androidPath} does not exist`));
+    return false;
+  }
+
+  //Validate that iosPaths exist
+  const iosEnvs = (config.iosPaths && _.keys(config.iosPaths)) || [];
+  iosEnvs.forEach(env => {
+    const path = config.iosPaths[env];
+    if (!fs.existsSync(path)) {
+      console.log(chalk.red(`Error: iosPath for ${env} at ${path} does not exist`));
+      return false;
+    }
+  });
+
+  // All good
+  return true;
+}
+
+function configure(configFilePath = `${process.cwd()}/rnbv.config.js`) {
+  if (!fs.existsSync(configFilePath)) {
+    console.log(chalk.red(`Error: missing rnbv config, set it up at rnbv.config.js`));
+    return;
+  }
+  config = require(`${process.cwd()}/rnbv.config.js`);
+}
+
+function run() {
+  configure();
+  if (!validate()) {
+    process.exit(1);
+  }
+  prompts({
+    type: 'select',
+    name: 'releaseType',
+    message: `Which version is the next release? (current is ${getIOSVersion()})`,
+    choices: [
+      { title: 'Major - X.x.x', value: 'major' },
+      { title: 'Minor - x.X.x', value: 'minor' },
+      { title: 'Patch - x.x.X', value: 'patch' },
+    ],
+    initial: 0,
+  }).then(({ releaseType }) => {
+    if (!releaseType) {
+      // User didn't select a release type
+      process.exit(2);
+    }
+
+    // Bump Android
+    android(releaseType);
+
+    // Bump iOS
+    const iosEnvs = (config.iosPaths && _.keys(config.iosPaths)) || [];
+    iosEnvs.forEach(env => ios(releaseType, env));
+  });
+}
+
+run();
+
+module.exports = {
+  run,
+  configure,
+  getAndroidVersion,
+  getIOSVersion,
+};


### PR DESCRIPTION
## Description
When sending a new version there is a manual step that we can never skip, that is bumping the version number of our app. Right now that means going to 4 different places if you count `dev`, `staging`, and `prod` for Android and iOS.

To help ensure that the versions for all envs are updated and to make it easier on the devs as well, I created a a script that can update the version for you in all places needed. Just select the type of version bump you want and done.

This script is heavily inspired in the lib [rnbv](https://www.npmjs.com/package/rnbv) which unfortunately does not support build targets for iOS and it also doesn't bump the android version code so we couldn't just use that.

For usage instructions see the changes in the readme file.

If you are working on an existing project and want to use this script, it should be fairly simple to apply the changes in this PR to it. Just make sure to update the `rnbv.config.js` file with the correct paths.