### PR TITLE
fix: use-form

### DIFF
--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -42,7 +42,7 @@ const useForm = (
       if (!validateAll && key) {
         setErrors({ ...errors, [key]: validations[key] });
       } else {
-        setErrors(validator(newValues));
+        setErrors(validations);
       }
     },
     [validator, errors, setErrors, validateAll],

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -38,11 +38,11 @@ const useForm = (
 
   const runValidations = useCallback(
     (newValues, key) => {
-      const validations = validator(newValues) || {};
+      const result = validator(newValues) || {};
       if (!validateAll && key) {
-        setErrors({ ...errors, [key]: validations[key] });
+        setErrors({ ...errors, [key]: result[key] });
       } else {
-        setErrors(validations);
+        setErrors(result);
       }
     },
     [validator, errors, setErrors, validateAll],


### PR DESCRIPTION
#### Ticket board reference:

- 

---

### Description:
The `useForm(..., validateAll: true)` was causing and issue in the validation 
`Array.isArray(errors[fieldKey]) ? errors[fieldKey][0] : errors[fieldKey] || ''` due to an `undefined` value on the `errors` variable.

**Evidence:**

https://user-images.githubusercontent.com/57040392/127875140-059084e1-0214-46b8-ab71-a3fa2e34e680.mov

---

#### Notes:

-

---

#### Tasks:

- [x] Tested on iOS
- [ ] Tested on Android
- [ ] Tested on a small device
- [ ] Tested accessibility
- [ ] Added tests


<!--- <img width='350' src=''/> -->