### PR TITLE
add: PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+### Pull request type
+
+<!-- Please check the type of change your PR introduces: -->
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, renaming)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] Documentation content changes
+- [ ] Other (please describe):
+
+---
+
+### Description
+
+<!--- Add a description of what is the aim of this PR --->
+
+---
+
+#### Jira board reference
+
+- [Jira_Card_Name](Jira_link_goes_here)
+
+---
+
+#### Notes:
+
+-
+
+---
+
+#### Tasks:
+
+- [ ] Tested on IOS
+- [ ] Tested on Android
+- [ ] Tested on a small device
+- [ ] Tested on a real device
+- [ ] Tested all flows related with this PR changes
+- [ ] Tested accessibility
+- [ ] Added tests
+
+---
+
+#### Preview
+
+<!--- <img width='350' src=''/> -->


### PR DESCRIPTION
Add PR template based on: [special-olympics](https://github.com/rootstrap/special-olympics-react-native/blob/950861a26146912df2e4b9bfe3c30069c59ba5c6/.github/PULL_REQUEST_TEMPLATE.MD) and [node-ts-api-base](https://github.com/rootstrap/node-ts-api-base/blob/master/.github/PULL_REQUEST_TEMPLATE.md) 

I think the most important thing to see first is the PR type and the description and then the rest. Let me know if you have any suggestion to improve this template. 