### PR TITLE
chore: Add typing to environment variables

### DIFF
--- a/src/@types/react-native-config.d.ts
+++ b/src/@types/react-native-config.d.ts
@@ -1,0 +1,8 @@
+declare module 'react-native-config' {
+  interface Environment {
+    API_URL: string;
+    BASE_URL: string;
+  }
+  const Config: Environment;
+  export default Config;
+}

--- a/src/network/client/index.ts
+++ b/src/network/client/index.ts
@@ -1,9 +1,5 @@
 import axios from 'axios';
-
-// TODO: replace with .env variables.
-const Config = {
-  API_URL: 'http://localhost:3000/api/',
-};
+import Config from 'react-native-config';
 
 const APPLICATION_JSON = 'application/json';
 export const MULTIPART_FORM_DATA = 'multipart/form-data';


### PR DESCRIPTION
Add types for `react-native-config` module for making environment variables type-safe.

| - | Before ❌ | After ✅ |
| - | - | - |
| Type checking | <img width="319" alt="image" src="https://user-images.githubusercontent.com/13039008/203855865-b2967faa-0ee0-45af-9307-ae9069556b79.png"> | <img width="797" alt="image" src="https://user-images.githubusercontent.com/13039008/203855947-253938a7-354f-4ae3-aeda-d91b5ac56c67.png"> |
| Autocomplete/Intellisense | <img width="417" alt="image" src="https://user-images.githubusercontent.com/13039008/203855016-7a5e03d1-f5f5-49de-8bd2-4a51314858a4.png"> | <img width="745" alt="image" src="https://user-images.githubusercontent.com/13039008/203854960-0e9f22e4-f4bd-4db4-8b90-f9c7f150d263.png"> |

