### PR TITLE
Feat: pressable button

### DIFF
--- a/src/common/Button/index.tsx
+++ b/src/common/Button/index.tsx
@@ -1,0 +1,18 @@
+import Pressable from 'common/Pressable';
+import React from 'react';
+import { Text } from 'react-native';
+
+import styles from './styles';
+import { ButtonProps } from './types';
+
+const Button: React.FunctionComponent<ButtonProps> = ({ title, disabled = false, ...props }) => (
+  <Pressable
+    containerStyle={styles.container}
+    disabledStyle={styles.disabledContainer}
+    disabled={disabled}
+    {...props}>
+    <Text style={[styles.title, disabled && styles.disabledTitle]}>{title}</Text>
+  </Pressable>
+);
+
+export default Button;

--- a/src/common/Button/styles.ts
+++ b/src/common/Button/styles.ts
@@ -1,0 +1,24 @@
+import { StyleSheet } from 'react-native';
+
+import { BLUE, GREY_01, GREY_02, WHITE } from 'constants/styles';
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 22,
+    backgroundColor: BLUE,
+    width: '80%',
+    margin: 10,
+  },
+  disabledContainer: {
+    backgroundColor: GREY_01,
+    borderColor: WHITE,
+  },
+  title: {
+    color: WHITE,
+  },
+  disabledTitle: {
+    color: GREY_02,
+  },
+});
+
+export default styles;

--- a/src/common/Button/types.ts
+++ b/src/common/Button/types.ts
@@ -1,0 +1,6 @@
+import { ComponentProps } from 'react';
+import { Pressable } from 'react-native';
+
+export type ButtonProps = {
+  title: string;
+} & ComponentProps<typeof Pressable>;

--- a/src/common/Pressable/index.tsx
+++ b/src/common/Pressable/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Pressable as RNPressable } from 'react-native';
+
+import styles from './styles';
+import { ButtonProps } from './types';
+
+const Pressable: React.FunctionComponent<ButtonProps> = ({
+  containerStyle,
+  disabledStyle,
+  disabled = false,
+  ...props
+}) => (
+  <RNPressable
+    accessibilityRole="button"
+    style={({ pressed }) => [
+      pressed ? styles.pressed : styles.notPressed,
+      styles.commonContainer,
+      containerStyle,
+      disabled && disabledStyle,
+    ]}
+    disabled={disabled}
+    {...props}
+  />
+);
+
+export default Pressable;

--- a/src/common/Pressable/styles.ts
+++ b/src/common/Pressable/styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  commonContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+    minWidth: 44,
+  },
+  pressed: {
+    opacity: 0.2,
+  },
+  notPressed: {
+    opacity: 1,
+  },
+});
+
+export default styles;

--- a/src/common/Pressable/types.ts
+++ b/src/common/Pressable/types.ts
@@ -1,0 +1,8 @@
+import { ComponentProps } from 'react';
+import { Pressable, ViewProps } from 'react-native';
+
+export type ButtonProps = {
+  containerStyle: ViewProps['style'];
+  disabledStyle: ViewProps['style'];
+  children: JSX.Element;
+} & ComponentProps<typeof Pressable>;

--- a/src/constants/styles.js
+++ b/src/constants/styles.js
@@ -1,0 +1,4 @@
+export const BLUE = '#42A6E3';
+export const GREY_01 = '#DADADA';
+export const GREY_02 = '#737373';
+export const WHITE = '#FFFFFF';

--- a/src/features/auth/welcome/screen/index.tsx
+++ b/src/features/auth/welcome/screen/index.tsx
@@ -1,5 +1,6 @@
+import Button from 'common/Button';
 import React from 'react';
-import { SafeAreaView, StatusBar, Text, TouchableOpacity, useColorScheme } from 'react-native';
+import { SafeAreaView, StatusBar, useColorScheme } from 'react-native';
 
 import styles from './styles';
 import { WelcomePropTypes } from './types';
@@ -13,20 +14,18 @@ const WelcomeScreen: React.FunctionComponent<WelcomePropTypes> = ({ navigation: 
   return (
     <SafeAreaView style={styles.container}>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <TouchableOpacity
+      <Button
         testID="dummy-button"
         accessibilityState={{ disabled: false }}
-        accessibilityRole={'button'}
-        onPress={onSignInPress}>
-        <Text>Sign In</Text>
-      </TouchableOpacity>
-      <TouchableOpacity
+        title="Sign In"
+        onPress={onSignInPress}
+      />
+      <Button
         testID="dummy-button"
         accessibilityState={{ disabled: false }}
-        accessibilityRole={'button'}
-        onPress={onSignUpPress}>
-        <Text>Sign Up</Text>
-      </TouchableOpacity>
+        title="Sign Up"
+        onPress={onSignUpPress}
+      />
     </SafeAreaView>
   );
 };


### PR DESCRIPTION
### Pull request type

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

---

### Description

- Create a custom pressable component with a highlight gesture when pressed, this component could be used for buttons, links, icons and any other pressable element. I also added a minimum size of 44px for accessibility purposes.
- Create a simple button wrapped with the previous pressable component.

---

#### Jira board reference

- [Button component](https://www.notion.so/rootstrap/274322b64619490488011b574816bfce?v=bc9fa864b81941d2afd477ff9a6d1680&p=50e1823b37b040edbd3ac12ca374d1c7&pm=s)

---

#### Notes:

- Pressable was released with React Native v0.63, it's explicitly suggested in the [official blog](https://reactnative.dev/blog/2020/07/06/version-0.63#pressable) to start using this component: 
_We expect that most people will build and share components utilizing Pressable under the hood instead of relying on the default experience of something like TouchableOpacity._
You can read [this article](https://blog.logrocket.com/react-native-touchable-vs-pressable-components/#touchableopacity-component) for more information.
---

#### Tasks:

- [x] Tested on IOS
- [x] Tested on Android
- [x] Tested on a small device
- [ ] Tested on a real device
- [ ] Tested all flows related with this PR changes
- [ ] Tested accessibility
- [ ] Added tests

---

#### Preview
<img width="473" alt="Screenshot 2022-12-22 at 15 56 03" src="https://user-images.githubusercontent.com/14322814/209209083-2cc54b15-8fa3-417b-9d07-367b21b7bbe8.png">

<img width="473" alt="Screenshot 2022-12-22 at 15 55 52" src="https://user-images.githubusercontent.com/14322814/209209098-a543b22f-2660-4bb9-a0be-3b54400dbf1a.png">
