### PR TITLE
Chore: Apply SemVer to both platforms

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,8 +104,6 @@ android {
         applicationId "com.reactnativebase"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
         resValue "string", "build_config_package", "com.reactnativebase"
     }
 
@@ -142,21 +140,29 @@ android {
     productFlavors {
         prod {
             resValue "string", "app_name", "ReactNativeBase"
+            versionCode 1
+            versionName "1.0.0"
         }
         develop {
             applicationIdSuffix '.dev'
             versionNameSuffix "- Develop"
             resValue "string", "app_name", "RNBase - Develop"
+            versionCode 1
+            versionName "1.0.0"
         }
         qa {
             applicationIdSuffix '.qa'
             versionNameSuffix "- QA"
             resValue "string", "app_name", "RNBase - QA"
+            versionCode 1
+            versionName "1.0.0"
         }
         staging {
             applicationIdSuffix '.staging'
             versionNameSuffix "- Staging"
             resValue "string", "app_name", "RNBase - Staging"
+            versionCode 1
+            versionName "1.0.0"
         }
     }
 

--- a/ios/ReactNativeBase.xcodeproj/project.pbxproj
+++ b/ios/ReactNativeBase.xcodeproj/project.pbxproj
@@ -542,7 +542,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -572,7 +572,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -820,7 +820,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -953,7 +953,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1086,7 +1086,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1211,7 +1211,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1332,7 +1332,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1453,7 +1453,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/rnb-cli/src/tools/rnbv.js
+++ b/rnb-cli/src/tools/rnbv.js
@@ -7,16 +7,19 @@ const semver = require("semver")
 
 const configMap = new Map([
   ["androidPath", "./android/app/build.gradle"],
-  ["iosPath", "./ios/ReactNativeBase/Info.plist"],
+  ["iosPath", "./ios/ReactNativeBase.xcodeproj/project.pbxproj"],
 ])
+let environment;
 
 const androidPath = configMap.get("androidPath")
 const iosPath = configMap.get("iosPath")
 
 const ANDROID_REGEX = /versionName "([.|\d]+)"/
 const ANDROID_REGEX_CODE = /versionCode \d+/
-const IOS_REGEX = /\s\<key\>CFBundleShortVersionString\<\/key\>\n\s+\<string\>(.+)\<\/string\>/m
-const IOS_REGEX_BUILD_NUMBER = /\s\<key\>CFBundleVersion\<\/key\>\n\s+\<string\>(.+)\<\/string\>/m
+const IOS_REGEX_PBX = /\s+MARKETING_VERSION = (.+);/m
+const IOS_REGEX_PBX_BUILD_NUMBER = /\s+CURRENT_PROJECT_VERSION = (.+);/m
+const REPLACE_IOS_PBX = /MARKETING_VERSION = .*;/
+const REPLACE_IOS_BUILD_PBX = /CURRENT_PROJECT_VERSION = .*;/
 
 function checkSemver(maybeSemver) {
   if (!semver.valid(maybeSemver)) {
@@ -25,35 +28,52 @@ function checkSemver(maybeSemver) {
 }
 
 function getAndroidVersion() {
+  const regExp = new RegExp(`${environment}\\s*\\{[^{}]*\}`);
+
   const file = fs.readFileSync(androidPath, "utf8")
-  const [_, current] = file.match(ANDROID_REGEX)
+  const [currentLine] = file.match(regExp);
+
+  const [, current] = currentLine.match(ANDROID_REGEX);
+
   checkSemver(current)
   return current
 }
 
 function getAndroidVersionCode() {
+  const regExp = new RegExp(`${environment}\\s*\\{[^{}]*\}`);
   const file = fs.readFileSync(androidPath, "utf8")
-  const [currentLine] = file.match(ANDROID_REGEX_CODE)
+
+  const [flavorBlock] = file.match(regExp);
+  const [currentLine] = flavorBlock.match(ANDROID_REGEX_CODE)
   const [current] = currentLine.match(/\d+/)
+
   return parseInt(current, 0)
 }
 
 function getIOSVersion() {
+  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi");
+
   const file = fs.readFileSync(iosPath, "utf8")
-  const [_, current] = file.match(IOS_REGEX)
+  const [, flavorBlock] = file.match(ENV_REGEX);
+
+  const [_, current] = flavorBlock.match(IOS_REGEX_PBX)
   checkSemver(current)
   return current
 }
 
 function getIOSBuildNumber() {
+  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi");
+
   const file = fs.readFileSync(iosPath, "utf8")
-  const [currentLine] = file.match(IOS_REGEX_BUILD_NUMBER)
-  const [current] = currentLine.match(/\d+/)
+  const [, flavorBlock] = file.match(ENV_REGEX)
+  const [currentVersion] = flavorBlock.match(IOS_REGEX_PBX_BUILD_NUMBER)
+  const [current] = currentVersion.match(/\d+/)
 
   return parseInt(current, 0)
 }
 
 function android(releaseType) {
+  const regExp = new RegExp(`${environment}\\s*\\{[^{}]*\}`)
   const updateOnlyCode = releaseType === "build"
 
   const currentVersion = getAndroidVersion()
@@ -66,14 +86,17 @@ function android(releaseType) {
   const nextCode = currentCode + 1
 
   const file = fs.readFileSync(androidPath, "utf8")
+  const [flavorBlock] = file.match(regExp);
 
-  let updated = file.replace(ANDROID_REGEX_CODE, `versionCode ${nextCode}`)
+  let updatedBlock = flavorBlock.replace(ANDROID_REGEX_CODE, `versionCode ${nextCode}`)
 
   if (!updateOnlyCode) {
-    updated = updated.replace(ANDROID_REGEX, `versionName "${nextVersion}"`)
+    updatedBlock = updatedBlock.replace(ANDROID_REGEX, `versionName "${nextVersion}"`)
   }
 
-  fs.writeFileSync(androidPath, updated, "utf8")
+  const updatedFile = file.replace(regExp, updatedBlock)
+
+  fs.writeFileSync(androidPath, updatedFile, "utf8")
   console.log(
     chalk.green(
       updateOnlyCode
@@ -84,6 +107,7 @@ function android(releaseType) {
 }
 
 function ios(releaseType) {
+  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi");
   const updateOnlyBuildNumber = releaseType === "build"
 
   const currentVersion = getIOSVersion()
@@ -93,23 +117,19 @@ function ios(releaseType) {
   }
 
   const currentBuildNumber = getIOSBuildNumber()
-  const nextBuildNumber = updateOnlyBuildNumber ? currentBuildNumber + 1 : 0
+  const nextBuildNumber = updateOnlyBuildNumber ? currentBuildNumber + 1 : 1
 
   const file = fs.readFileSync(iosPath, "utf8")
+  const [, flavorBlock] = file.match(ENV_REGEX)
 
-  let updated = file.replace(
-    `<string>${currentBuildNumber}</string>`,
-    `<string>${nextBuildNumber}</string>`,
-  )
+  let updatedBlock = flavorBlock.replace(REPLACE_IOS_BUILD_PBX, `CURRENT_PROJECT_VERSION = ${nextBuildNumber};`)
 
   if (!updateOnlyBuildNumber) {
-    updated = updated.replace(
-      `<string>${currentVersion}</string>`,
-      `<string>${nextVersion}</string>`,
-    )
+    updatedBlock = updatedBlock.replace(REPLACE_IOS_PBX, `MARKETING_VERSION = ${nextVersion};`)
   }
-
-  fs.writeFileSync(iosPath, updated, "utf8")
+  let occurrences = 0;
+  const updatedFile = file.replace(ENV_REGEX, match => ++occurrences === 2 ? updatedBlock : match)
+  fs.writeFileSync(iosPath, updatedFile, "utf8")
 
   console.log(
     chalk.green(
@@ -120,11 +140,28 @@ function ios(releaseType) {
   )
 }
 
-function run() {
-  configure()
-  if (!validate()) {
-    process.exit(1)
-  }
+function selectEnvironment() {
+  prompts({
+    type: "select",
+    name: "newEnv",
+    message: "Which environment do you want to release?",
+    choices: [
+      { title: "Development", value: "develop" },
+      { title: "Staging", value: "staging" },
+      { title: "Production", value: "prod" },
+      { title: "QA", value: "qa" },
+    ],
+    initial: 0,
+  }).then(({ newEnv }) => {
+    if (!newEnv) {
+      process.exit(2)
+    }
+    environment = newEnv
+    selectReleaseType()
+  })
+}
+
+function selectReleaseType() {
   prompts({
     type: "select",
     name: "releaseType",
@@ -143,6 +180,14 @@ function run() {
     android(releaseType)
     ios(releaseType)
   })
+}
+
+function run() {
+  configure()
+  if (!validate()) {
+    process.exit(1)
+  }
+  selectEnvironment()
 }
 
 function validate() {

--- a/rnb-cli/src/tools/rnbv.js
+++ b/rnb-cli/src/tools/rnbv.js
@@ -9,7 +9,7 @@ const configMap = new Map([
   ["androidPath", "./android/app/build.gradle"],
   ["iosPath", "./ios/ReactNativeBase.xcodeproj/project.pbxproj"],
 ])
-let environment;
+let environment
 
 const androidPath = configMap.get("androidPath")
 const iosPath = configMap.get("iosPath")
@@ -28,22 +28,22 @@ function checkSemver(maybeSemver) {
 }
 
 function getAndroidVersion() {
-  const regExp = new RegExp(`${environment}\\s*\\{[^{}]*\}`);
+  const regExp = new RegExp(`${environment}\\s*\\{[^{}]*\}`)
 
   const file = fs.readFileSync(androidPath, "utf8")
-  const [currentLine] = file.match(regExp);
+  const [currentLine] = file.match(regExp)
 
-  const [, current] = currentLine.match(ANDROID_REGEX);
+  const [, current] = currentLine.match(ANDROID_REGEX)
 
   checkSemver(current)
   return current
 }
 
 function getAndroidVersionCode() {
-  const regExp = new RegExp(`${environment}\\s*\\{[^{}]*\}`);
+  const regExp = new RegExp(`${environment}\\s*\\{[^{}]*\}`)
   const file = fs.readFileSync(androidPath, "utf8")
 
-  const [flavorBlock] = file.match(regExp);
+  const [flavorBlock] = file.match(regExp)
   const [currentLine] = flavorBlock.match(ANDROID_REGEX_CODE)
   const [current] = currentLine.match(/\d+/)
 
@@ -51,10 +51,10 @@ function getAndroidVersionCode() {
 }
 
 function getIOSVersion() {
-  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi");
+  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi")
 
   const file = fs.readFileSync(iosPath, "utf8")
-  const [, flavorBlock] = file.match(ENV_REGEX);
+  const [, flavorBlock] = file.match(ENV_REGEX)
 
   const [_, current] = flavorBlock.match(IOS_REGEX_PBX)
   checkSemver(current)
@@ -62,7 +62,7 @@ function getIOSVersion() {
 }
 
 function getIOSBuildNumber() {
-  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi");
+  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi")
 
   const file = fs.readFileSync(iosPath, "utf8")
   const [, flavorBlock] = file.match(ENV_REGEX)
@@ -86,7 +86,7 @@ function android(releaseType) {
   const nextCode = currentCode + 1
 
   const file = fs.readFileSync(androidPath, "utf8")
-  const [flavorBlock] = file.match(regExp);
+  const [flavorBlock] = file.match(regExp)
 
   let updatedBlock = flavorBlock.replace(ANDROID_REGEX_CODE, `versionCode ${nextCode}`)
 
@@ -107,7 +107,7 @@ function android(releaseType) {
 }
 
 function ios(releaseType) {
-  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi");
+  const ENV_REGEX = new RegExp(`release-${environment} [\\s\\S]*?\\{([\\s\\S]*?)\\}`, "gi")
   const updateOnlyBuildNumber = releaseType === "build"
 
   const currentVersion = getIOSVersion()
@@ -122,13 +122,18 @@ function ios(releaseType) {
   const file = fs.readFileSync(iosPath, "utf8")
   const [, flavorBlock] = file.match(ENV_REGEX)
 
-  let updatedBlock = flavorBlock.replace(REPLACE_IOS_BUILD_PBX, `CURRENT_PROJECT_VERSION = ${nextBuildNumber};`)
+  let updatedBlock = flavorBlock.replace(
+    REPLACE_IOS_BUILD_PBX,
+    `CURRENT_PROJECT_VERSION = ${nextBuildNumber};`,
+  )
 
   if (!updateOnlyBuildNumber) {
     updatedBlock = updatedBlock.replace(REPLACE_IOS_PBX, `MARKETING_VERSION = ${nextVersion};`)
   }
-  let occurrences = 0;
-  const updatedFile = file.replace(ENV_REGEX, match => ++occurrences === 2 ? updatedBlock : match)
+  let occurrences = 0
+  const updatedFile = file.replace(ENV_REGEX, (match) =>
+    ++occurrences === 2 ? updatedBlock : match,
+  )
   fs.writeFileSync(iosPath, updatedFile, "utf8")
 
   console.log(


### PR DESCRIPTION
### Pull request type

<!-- Please check the type of change your PR introduces: -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

---

### Description

Both platforms' versions by default were set to 1.0.

**Android** version and build number were handled in the `defaultConfig` and not in each flavor.
**iOS** Have schemes allowing us to edit versions and build numbers per each environment.

These changes allow us to change flavors and scheme versions, asking which environment to use and then what number to bump (major, minor, patch, build).


---

#### Jira board reference

- N/A

---

#### Notes:

-

---

#### Tasks:

- [ ] Tested on IOS
- [ ] Tested on Android
- [ ] Tested on a small device
- [ ] Tested on a real device
- [ ] Tested all flows related with this PR changes
- [ ] Tested accessibility
- [ ] Added tests

---

#### Preview

<!--- <img width='350' src=''/> -->


https://github.com/rootstrap/react-native-base/assets/17632690/7d0bf887-686d-4855-af78-9ecb2168b879

